### PR TITLE
fixes to hsic.py 

### DIFF
--- a/source/hsicbt/math/hsic.py
+++ b/source/hsicbt/math/hsic.py
@@ -1,7 +1,8 @@
 import torch
 import numpy as np
 from torch.autograd import Variable, grad
-
+# pylint: disable=no-member
+# pylint: disable=not-callable
 def sigma_estimation(X, Y):
     """ sigma from median distance
     """
@@ -16,43 +17,55 @@ def sigma_estimation(X, Y):
         med=1E-2
     return med
 
-def distmat(X):
-    """ distance matrix
+def distmat(X, requires_grad=True):
+    """  distance matrix  |X.X - 2(X x Xt) + (X.X)t|
+    Args
+        X               (tensor) shape (batchsize, dims)
+        requires_grad   (bool[True]) False: removes gradient from output
     """
-    r = torch.sum(X*X, 1)
-    r = r.view([-1, 1])
-    a = torch.mm(X, torch.transpose(X,0,1))
-    D = r.expand_as(a) - 2*a +  torch.transpose(r,0,1).expand_as(a)
-    D = torch.abs(D)
-    return D
+    _cloned = False
+    if X.requires_grad and not requires_grad:
+        X = X.clone().detach()
+        _cloned = True
+    out = torch.mm(X, X.T).mul_(-2.0)
+    out.add_((X*X).sum(1, keepdim=True))
+    out.add_((X*X).sum(1, keepdim=True).T)
+    if _cloned:
+        del X
+    return out.abs_()
 
-def kernelmat(X, sigma):
+def kernelmat(X, sigma=None, requires_grad=True):
     """ kernel matrix baker
+        Args
+            X             (tensor) shape (batchsize, dims)
+            sigma         (float [None]) from config
+            requires_grad (bool [True]) False: removes gradient from output
+
     """
-    m = int(X.size()[0])
-    dim = int(X.size()[1]) * 1.0
-    H = torch.eye(m) - (1./m) * torch.ones([m,m])
-    Dxx = distmat(X)
-    
+    m, dim = X.size()
+    H = torch.eye(m, device=X.device).sub_(1/m)
+    Kx = distmat(X, requires_grad=requires_grad)
+
     if sigma:
-        variance = 2.*sigma*sigma*X.size()[1]            
-        Kx = torch.exp( -Dxx / variance).type(torch.FloatTensor)   # kernel matrices        
-        # print(sigma, torch.mean(Kx), torch.max(Kx), torch.min(Kx))
+        variance = 2.*sigma*sigma*dim
+        torch.exp_(Kx.mul_(-1.0/variance))
     else:
         try:
-            sx = sigma_estimation(X,X)
-            Kx = torch.exp( -Dxx / (2.*sx*sx)).type(torch.FloatTensor)
+            sx = sigma_estimation(X, X)
+            variance = 2.*sx*sx
+            torch.exp_(Kx.mul_(-1.0/variance))
         except RuntimeError as e:
             raise RuntimeError("Unstable sigma {} with maximum/minimum input ({},{})".format(
                 sx, torch.max(X), torch.min(X)))
 
-    Kxc = torch.mm(Kx,H)
-
+    Kxc = torch.mm(Kx, H)
+    del H
+    del Kx
     return Kxc
 
 def distcorr(X, sigma=1.0):
     X = distmat(X)
-    X = torch.exp( -X / (2.*sigma*sigma))
+    X = torch.exp(-X / (2.*sigma*sigma))
     return torch.mean(X)
 
 def compute_kernel(x, y):
@@ -137,21 +150,28 @@ def hsic_normalized(x, y, sigma=None, use_cuda=True, to_numpy=True):
     thehsic = Pxy/(Px*Py)
     return thehsic
 
-def hsic_normalized_cca(x, y, sigma, use_cuda=True, to_numpy=True):
+def hsic_normalized_cca(x, y, sigma=None, requires_grad=True):
     """
+        Args
+            x       (tensor) shape (batchsize, dims)
+            y       (tensor) shape (batchsize, dims)
+            sigma   (float [None])
+            requires_grad   (bool[True]) False: removes gradient from output
     """
-    m = int(x.size()[0])
-    Kxc = kernelmat(x, sigma=sigma)
-    Kyc = kernelmat(y, sigma=sigma)
-
     epsilon = 1E-5
-    K_I = torch.eye(m)
-    Kxc_i = torch.inverse(Kxc + epsilon*m*K_I)
-    Kyc_i = torch.inverse(Kyc + epsilon*m*K_I)
-    Rx = (Kxc.mm(Kxc_i))
-    Ry = (Kyc.mm(Kyc_i))
-    Pxy = torch.sum(torch.mul(Rx, Ry.t()))
+    m = x.size()[0]
+    K_I = torch.eye(m, device=x.device).mul_(epsilon*m)
 
-    return Pxy
+    Kc = kernelmat(x, sigma=sigma, requires_grad=requires_grad)
+    Rx = Kc.mm(Kc.add(K_I).inverse())
 
+    Kc = kernelmat(y, sigma=sigma, requires_grad=requires_grad)
+    Ry = Kc.mm(Kc.add(K_I).inverse())
 
+    out = Rx.mul_(Ry.t()).sum()
+
+    del Rx
+    del Ry
+    del Kc
+    del K_I
+    return out


### PR DESCRIPTION
Ok, this is the correct branch to create pull request  -- same coment as the one i closed. this one has only one file. 

Hi Kurt, I used 3 functions from hsic and noticed a few things

    you can allocate much less memory by using in place functions, one shouldnt do that in the model but in the loss function that is ok, because loss is the source of of the gradient it simply copies the value to the grad.
    for some reason your kernelmat you cast a new tensor in the -e^(d/v), i removed that - so now if X device is cuda, the device doesnt die. Also, recasting a Float Tensor introduces floating point errors, not significant in this context but i dont know how they would propagate.
    I added a linting mute so my vscode doesnt flag torch. or as wrong

    If you want look at the reasoning, tests and timing, I have a jupyter in my dev branch where I tested the changes.
    https://github.com/xvdp/HSIC-bottleneck/blob/xvdp_dev/jupyter/HSIC_Kernel.ipynb
    I only changed the 3 functions that i was using
    distmat()
    kernelmat()
    hsic_normalized_cca()